### PR TITLE
[FIX] Heroku deployment gem location and config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'turbolinks', '~> 5'
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'cartify', github: 'CraftAcademy/cartify', branch: 'rails_5_2'
 
 
 group :development, :test do
@@ -28,7 +29,6 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'faker'
   gem 'devise'
-  gem 'cartify', github: 'CraftAcademy/cartify', branch: 'rails_5_2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/CraftAcademy/cartify.git
-  revision: e03d073a59b28552701b8932cb242eec7faea1d9
+  revision: 5382f3fcf87b332a3e91a9c871b1edff57125025
   branch: rails_5_2
   specs:
-    cartify (0.2.7.pre.custom)
+    cartify (0.2.9.pre.custom)
       bootstrap (~> 4.1, >= 4.1.1)
       country_select (~> 3.1)
       devise (~> 4.3)
@@ -403,4 +403,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.5
+   1.17.0.pre.1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
## Fix PR

Heroku deployment failing due to inability to complete rake / precompile assets.

## Fix includes:

* Moved cartify gem to production environment
* Rebundled and created new gemfile.lock
* Revised production.rb for new js.compressor config: ```config.assets.js_compressor = Uglifier.new(harmony: true)```)